### PR TITLE
AF v1.5.2.1

### DIFF
--- a/AdvancedFilters.txt
+++ b/AdvancedFilters.txt
@@ -1,10 +1,10 @@
 ## Title: Advanced Filters
 ## Author: Randactyl
-## Version: 1.5.1.8
-## AddOnVersion: 1518
+## Version: 1.5.2.1
+## AddOnVersion: 1521
 ## APIVersion: 100028 100029
 ## DependsOn: LibFilters-3.0 LibCustomMenu libCommonInventoryFilters LibMotifCategories
-## OptionalDependsOn: LibAddonMenu-2.0 CraftBagExtended
+## OptionalDependsOn: LibAddonMenu-2.0 CraftBagExtended Multicraft
 ## SavedVariables: AdvancedFilters_Settings
 
 constants.lua

--- a/constants.lua
+++ b/constants.lua
@@ -4,10 +4,30 @@ local AF = AdvancedFilters
 --Addon base variables
 AF.name = "AdvancedFilters"
 AF.author = "ingeniousclown, Randactyl, Baertram"
-AF.version = "1.5.1.8"
+AF.version = "1.5.2.1"
 AF.savedVarsVersion = 1.511
 AF.website = "http://www.esoui.com/downloads/info245-AdvancedFilters.html"
+AF.feedback = "https://www.esoui.com/portal.php?id=136&a=faq"
+AF.donation = "https://www.esoui.com/portal.php?id=136&a=faq&faqid=131"
 AF.currentInventoryType = INVENTORY_BACKPACK
+
+AF.clientLang = GetCVar("language.2")
+
+--SavedVariables default settings
+AF.defaultSettings = {
+    doDebugOutput                           = false,
+    hideItemCount                           = false,
+    itemCountLabelColor = {
+        ["r"] = 1,
+        ["g"] = 1,
+        ["b"] = 1,
+        ["a"] = 1,
+    },
+    hideSubFilterLabel                      = false,
+    grayOutSubFiltersWithNoItems            = true,
+    showIconsInFilterDropdowns              = true,
+    rememberFilterDropdownsLastSelection    = true,
+}
 
 --Libraries
 AF.util = AF.util or {}
@@ -32,6 +52,13 @@ if not util.LibMotifCategories then d("[AdvancedFilters]ERROR: Needed library Li
 ------------------------------------------------------------------------------------------------------------------------
 -- Libraries - END
 ---------------------------------------------------------------------------------------------------------------------------
+
+--Other addons
+AF.otherAddons = {}
+
+--Error strings for thrown addon errors and chat output
+AF.errorStrings = {}
+AF.errorStrings["MultiCraft"] = "PLEASE DISABLE THE ADDON \'MultiCraft\'! AdvancedFilters cannot work if this addon is enabled. \'Multicraft\' has been replaced by ZOs own multi crafting UI so you do not need it anymore!"
 
 --Scene names for the SCENE_MANAGER.currentScene.name check
 local scenesForChecks = {

--- a/data.lua
+++ b/data.lua
@@ -674,7 +674,9 @@ AF.subfilterCallbacks = {
             dropdownCallbacks = {},
         },
         Container = {
-            filterCallback = GetFilterCallbackForItemTypeAndSpecializedItemtype({ITEMTYPE_CONTAINER, ITEMTYPE_CONTAINER_CURRENCY, ITEMFILTERTYPE_PROVISIONING}, {SPECIALIZED_ITEMTYPE_CONTAINER}),
+            filterCallback = GetFilterCallbackForItemTypeAndSpecializedItemtype(
+                    {ITEMTYPE_CONTAINER, ITEMTYPE_CONTAINER_CURRENCY, ITEMFILTERTYPE_PROVISIONING},
+                    {SPECIALIZED_ITEMTYPE_CONTAINER, SPECIALIZED_ITEMTYPE_CONTAINER_EVENT, SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE}),
             dropdownCallbacks = {},
         },
         Repair = {

--- a/menu.lua
+++ b/menu.lua
@@ -25,7 +25,9 @@ function AF.LAMSettingsMenu()
             registerForRefresh 	= true,
             registerForDefaults = true,
             slashCommand 		= "/afs",
-            website             = AF.website
+            website             = AF.website,
+            feedback            = AF.feedback,
+            donation            = AF.donation,
         }
         --The LibAddonMenu2.0 settings panel reference variable
         AF.LAMsettingsPanel = AF.LAM:RegisterAddonPanel(AF.name .. "_LAM", panelData)
@@ -95,6 +97,17 @@ function AF.LAMSettingsMenu()
                     AF.settings.showIconsInFilterDropdowns = value
                 end,
                 default = defSettings.showIconsInFilterDropdowns,
+            },
+            --==============================================================================
+            {
+                type = "checkbox",
+                name = strings.lamRememberFilterDropdownsLastSelection,
+                tooltip = strings.lamRememberFilterDropdownsLastSelectionTT,
+                getFunc = function() return settings.rememberFilterDropdownsLastSelection end,
+                setFunc = function(value)
+                    AF.settings.rememberFilterDropdownsLastSelection = value
+                end,
+                default = defSettings.rememberFilterDropdownsLastSelection,
             },
             --==============================================================================
             --                              DEBUG

--- a/strings/de.lua
+++ b/strings/de.lua
@@ -1,5 +1,5 @@
 local util = AdvancedFilters.util
-local enStrings = AdvancedFilters.strings
+local enStrings = AdvancedFilters.ENstrings
 local strings = {
     TwoHandAxe = util.Localize(zo_strformat("<<1>> <<2>>", GetString(SI_EQUIPTYPE6), GetString(SI_WEAPONTYPE1))),
     TwoHandSword = util.Localize(zo_strformat("<<1>> <<2>>", GetString(SI_EQUIPTYPE6), GetString(SI_WEAPONTYPE3))),
@@ -21,6 +21,11 @@ local strings = {
     lamGrayOutSubFiltersWithNoItemsTT = "Deaktiviert die Filter Kategorien, welche aktuell keine Gegegnstände besitzen.",
     lamShowIconsInFilterDropdowns = "Zeige Symbole in Filter Boxen",
     lamShowIconsInFilterDropdownsTT = "Zeige Symbole in den Filter Aufklapp Boxen an",
+    lamRememberFilterDropdownsLastSelection = "Merke letzte Filter Box Auswahl",
+    lamRememberFilterDropdownsLastSelectionTT = "Merkt sich je Unterfilter und Filter Panel (Inventar, Mail senden, Handerksstation, ...) die letzte Filter Box Auswahl und stellt diese wieder her, wenn du den Unterfilter auf diesem Filter Panel das nächste mal besuchst.\NDies wird NICHT über eine Ausloggen/Benutzeroberfläche Neuladen hinweg gemerkt!",
+
+    --Error messages
+    errorCheckChatPlease = "|cFF0000[AdvancedFilters FEHLER]|r Bitte lese die Fehlermeldung im Chat!",
 }
 setmetatable(strings, {__index = enStrings})
 AdvancedFilters.strings = strings

--- a/strings/en.lua
+++ b/strings/en.lua
@@ -190,7 +190,12 @@ local strings = {
     lamGrayOutSubFiltersWithNoItemsTT = "Disable the subfilter buttons where no items are available.",
     lamShowIconsInFilterDropdowns = "Show icons in dropdown box",
     lamShowIconsInFilterDropdownsTT = "Show icons for the filter entries in the filter dropdown boxes",
-    lamDebugOutput = "Debug"
+    lamRememberFilterDropdownsLastSelection = "Remember last filter dropdown selection",
+    lamRememberFilterDropdownsLastSelectionTT = "Remenber the last filter dropdown box at each subfilter and filterpanel (inventory, mail, crafting table, ...) and re-apply this filter in the dropdown entry if you return to this filterpanel and subfilter.\nThis will NOT be saved if you logout/do a reload of the UI!",
+    lamDebugOutput = "Debug",
+
+    --Error messages
+    errorCheckChatPlease = "|cFF0000[AdvancedFilters ERROR]|r Please read the chat error message!",
 }
 strings.Vanity = strings.Disguise
 
@@ -235,4 +240,5 @@ strings.Swift_Neck = strings.Swift .. neckStr
 strings.Triune_Neck = strings.Triune .. neckStr
 strings.Protective_Neck = strings.Protective .. neckStr
 
+AdvancedFilters.ENstrings = strings
 AdvancedFilters.strings = strings

--- a/strings/es.lua
+++ b/strings/es.lua
@@ -1,5 +1,5 @@
 local util = AdvancedFilters.util
-local enStrings = AdvancedFilters.strings
+local enStrings = AdvancedFilters.ENstrings
 local strings = {
      --WEAPON
     OneHand = "Una Mano",

--- a/strings/fr.lua
+++ b/strings/fr.lua
@@ -1,5 +1,5 @@
 local util = AdvancedFilters.util
-local enStrings = AdvancedFilters.strings
+local enStrings = AdvancedFilters.ENstrings
 local strings = {
     --WEAPON
     OneHand = "Une main",
@@ -36,7 +36,10 @@ local strings = {
     lamGrayOutSubFiltersWithNoItemsTT = "Masque le bouton des sous-catégories ne comportant aucun objet.",
     lamShowIconsInFilterDropdowns = "Afficher les icônes dans le menu déroulant",
     lamShowIconsInFilterDropdownsTT = "Affiche les icônes des sous-catégories d'objet dans le menu déroulant de filtrage par type d'objet.",
-    lamDebugOutput = "Déboguage"
+    lamDebugOutput = "Déboguage",
+
+    --Error messages
+    errorCheckChatPlease = "|cFF0000[AdvancedFilters ERREUR]|r Veuillez lire le message d'erreur du chat!",
 }
 
 setmetatable(strings, {__index = enStrings})

--- a/strings/jp.lua
+++ b/strings/jp.lua
@@ -1,5 +1,5 @@
 local util = AdvancedFilters.util
-local enStrings = AdvancedFilters.strings
+local enStrings = AdvancedFilters.ENstrings
 local strings = {
     --WEAPON
     OneHand = "片手武器",
@@ -43,6 +43,9 @@ local strings = {
     --DROPDOWN CONTEXT MENU
     ResetToAll = "全てリセット",
     InvertDropdownFilter = "フィルターを反転: %s",
+
+    --Error messages
+    errorCheckChatPlease = "|cFF0000[AdvancedFilters エラー]|r チャットエラーメッセージをお読みください!",
 }
 setmetatable(strings, {__index = enStrings})
 AdvancedFilters.strings = strings

--- a/strings/ru.lua
+++ b/strings/ru.lua
@@ -1,5 +1,5 @@
 local util = AdvancedFilters.util
-local enStrings = AdvancedFilters.strings
+local enStrings = AdvancedFilters.ENstrings
 local strings = {
     --SHARED
     All = "Все",
@@ -54,6 +54,9 @@ local strings = {
     lamHideItemCountColorTT = "Установить цвет количество предметов в нижней строке инвентаря",
     lamHideSubFilterLabel = "Скрыть метку подфильтра",
     lamHideSubFilterLabelTT = "Скрыть метку описания подфильтра в верхней строке инвентаря (слева от кнопок подфильтров).",
+
+    --Error messages
+    errorCheckChatPlease = "|cFF0000[AdvancedFilters ОШИБКА]|r Пожалуйста, прочитайте сообщение об ошибке чата!",
 }
 setmetatable(strings, {__index = enStrings})
 

--- a/util.lua
+++ b/util.lua
@@ -45,11 +45,11 @@ function util.AbortSubfilterRefresh(inventoryType)
     return doAbort
 end
 
-function util.ApplyFilter(button, filterTag, requestUpdate)
+function util.ApplyFilter(button, filterTag, requestUpdate, filterType)
 
-    local LibFilters = util.LibFilters
-    local callback = button.filterCallback
-    local filterType = util.GetCurrentFilterTypeForInventory(AF.currentInventoryType)
+    local LibFilters        = util.LibFilters
+    local callback          = button.filterCallback
+    local filterTypeToUse   = filterType or util.GetCurrentFilterTypeForInventory(AF.currentInventoryType)
 
 --d("[AF]Apply " .. button.name .. " from " .. filterTag .. " for filterType " .. filterType .. " and inventoryType " .. AF.currentInventoryType)
 
@@ -58,7 +58,7 @@ function util.ApplyFilter(button, filterTag, requestUpdate)
         d("callback was nil for " .. filterTag)
         return
     end
-    if filterType == nil then
+    if filterTypeToUse == nil then
         d("filterType was nil for " .. filterTag)
         return
     end
@@ -66,13 +66,20 @@ function util.ApplyFilter(button, filterTag, requestUpdate)
     --first, clear current filters without an update
     LibFilters:UnregisterFilter(filterTag)
     --then register new one and hand off update parameter
-    LibFilters:RegisterFilter(filterTag, filterType, callback)
-    if requestUpdate == true then LibFilters:RequestUpdate(filterType) end
+    LibFilters:RegisterFilter(filterTag, filterTypeToUse, callback)
+    if requestUpdate == true then LibFilters:RequestUpdate(filterTypeToUse) end
 
     --Update the count of filtered/shown items in the inventory FreeSlot label
     --Delay this function call as the data needs to be filtered first!
     zo_callLater(function()
         util.updateInventoryInfoBarCountLabel(AF.currentInventoryType)
+
+        --Run an end callback function now?
+        local endCallback = button.filterEndCallback
+        if endCallback and type(endCallback) == "function" then
+d("[AF]blubb")
+            endCallback()
+        end
     end, 50)
 end
 


### PR DESCRIPTION
Version 1.5.2.1
-Added setting to remember last dropdown filterbox entry
-Fixed error message showing if debug messages are enabled but everythign was ok
-Added dropdown filters new "run afer all filters are applied" function. It must be applied to the filterInformation ->  subtable callbackTable, and there as function unter the key "filterEndCallback"

Version 1.5.2.0
Changed:
-If you are using the addon "MultiCraft" AdvancedFilters will now stop to work. It will show an onscreen message about the chat and show the information to disable MultiCraft into the chat.
-Chat error messages will be shown if a translation text is missing. PLease report the error message !and the information given in them! to me via the addon comments.
-An on screen message will be shown now if an AdvancedFilters related error message was written to the chat

Fixed:
-Containers for events and stylepages wil lbe shown below consumables->containers again
-Added error messages if some of the translation strings related lua error messages occur. The addon will continue to work but texts wil lbe shown as "ERROR: n/a" then. Please check the chat message then and provide me the information.

Version 1.5.1.9
Added a quick and dirty nil check to suppress error message in line 38 of AF_FilterBar.lua

Version 1.5.1.8
Made compatible with Scalebreaker patch.

Added
-Dropdown filter context menu shows tooltip if text inside is to long to show completely
-Dropdown filter context menu right click menu will show the name of the active filter inside the "Invert" option now
-Dropdown filter invert option will show a "≠" sign in front of the filter name if the inverted filter is currently active

Fixed
Several bugs:
#3. Error message upon loading of the game on live (User: darkedone02)
#5. Error upon opening vendor BUY panel
#6. Guild store sell tab shows subcategories enabled where there are no items in there to sell (maybe bound items exist, or stolen ones)
#7. Junk in inventory: "jewelry" will show as armor AND jewelry, but should only be shown below jewelry
#8. Dropdown filter will re-apply the inverted filter properly if you reopen this subfilter group

Tried to fix:
#1. Error message on PTS if opening the Enchanting table: Not reproducable. Added more checks and added a debug message which will be shown instead of the error if you enable the debug mdoe in the settings!

#4 new summerset master furnisher's documents are hidden: Not reproducable as achievement/writ vouchers are missing. Added a new function to add itemfiltertype_provisioning and specializedfiltertype_container to the consumables->container items

#2. Error message upon doing something at crafting station (User: Phuein)
Not reproducable. Added more checks and added a debug message which will be shown instead of the error if you enable the debug mdoe in the settings!
